### PR TITLE
Bug fix for http://github.com/CakeDC/Search/issues#issue/3

### DIFF
--- a/models/behaviors/searchable.php
+++ b/models/behaviors/searchable.php
@@ -246,7 +246,7 @@ class SearchableBehavior extends ModelBehavior {
 		if (strpos($fieldName, '.') === false) {
 			$fieldName = $model->alias . '.' . $fieldName;
 		}
-		if (!empty($data[$field['name']]) || (isset($data[$field['name']]) && (int)$data[$field['name']] === 0)) {
+		if (!empty($data[$field['name']]) || (isset($data[$field['name']]) && ($data[$field['name']] === 0 || $data[$field['name']] === '0'))) {
 			$conditions[$fieldName] = $data[$field['name']];
 		}
 		return $conditions;

--- a/tests/cases/behaviors/searchable.test.php
+++ b/tests/cases/behaviors/searchable.test.php
@@ -169,6 +169,18 @@ class SearchableTestCase extends CakeTestCase {
 		$data = array('views' => '0');
 		$result = $this->Article->parseCriteria($data);
 		$this->assertEqual($result, array('Article.views' => 0));
+		
+		$this->Article->filterArgs = array(
+			array('name' => 'views', 'type' => 'value'));
+		$data = array('views' => 0);
+		$result = $this->Article->parseCriteria($data);
+		$this->assertEqual($result, array('Article.views' => 0));
+		
+		$this->Article->filterArgs = array(
+			array('name' => 'views', 'type' => 'value'));
+		$data = array('views' => '');
+		$result = $this->Article->parseCriteria($data);
+		$this->assertEqual($result, array());
 	}
 
 /**


### PR DESCRIPTION
Fixed a bug created by the patch for http://github.com/CakeDC/Search/issues#issue/3 where empty values where being converted to '0' and so creating unexpected search results.

The code was converting things to (int), so empty values were converted to 0 and so an empty search was generating the following sql: Model.field = ''
