### PR TITLE
Fixed a bug in the Prg components for checkboxes

### DIFF
--- a/controllers/components/prg.php
+++ b/controllers/components/prg.php
@@ -125,7 +125,7 @@ class PrgComponent extends Object {
 	public function serializeParams(&$data) {
 		foreach ($this->controller->presetVars as $field) {
 			if ($field['type'] == 'checkbox') {
-				if (is_array($data[$field['field']])) {
+				if (array_key_exists($field['field'], $data) && is_array($data[$field['field']])) {
 					$values = join('|', $data[$field['field']]);
 				} else {
 					$values = '';

--- a/tests/cases/components/prg.test.php
+++ b/tests/cases/components/prg.test.php
@@ -279,6 +279,10 @@ class PrgComponentTest extends CakeTestCase {
 
 		$result = $this->Controller->Prg->serializeParams($testData);
 		$this->assertEqual($result, array('options' => ''));
+
+		$testData = array();
+		$result = $this->Controller->Prg->serializeParams($testData);
+		$this->assertEqual($result, array('options' => ''));
 	}
 
 /**


### PR DESCRIPTION
See the added test.
This error occurs in the case the request does not contain data for the key aimed at containing the checkboxes values. For instance if the same action is triggered for a "normal" search (without checkboxes) and "advanced" search  (with checkboxes), it will trigger a notice on the normal search
