### PR TITLE
Invalid field if field is set to encode, sorting, and field not in url.

### DIFF
--- a/controllers/components/prg.php
+++ b/controllers/components/prg.php
@@ -72,8 +72,10 @@ class PrgComponent extends Object {
 
 		foreach ($this->controller->presetVars as $field) {
 			if ($this->encode == true || isset($field['encode']) && $field['encode'] == true) {
-				// Its important to set it also back to the controllers passed args!
-				$this->controller->passedArgs[$field['field']] = $args[$field['field']] = pack('H*', $args[$field['field']]);
+				if (isset($args[$field['field']])) {
+					// Its important to set it also back to the controllers passed args!
+					$this->controller->passedArgs[$field['field']] = $args[$field['field']] = pack('H*', $args[$field['field']]);
+				}
 			}
 
 			if ($field['type'] == 'lookup') {


### PR DESCRIPTION
If the field is set to 'encode' => true and is not in the url (not filtered), then it will throw an undefined index when a sort happens. Added a check to see if the field is set.
