### PR TITLE
adding isset check to stop undefined index error when using encode=true...

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -135,7 +135,7 @@ class PrgComponent extends Component {
 				$data[$field['field']] = $values;
 			}
 
-			if ($this->encode == true || isset($field['encode']) && $field['encode'] == true && isset($data[$field['field']])) {
+			if (($this->encode == true || isset($field['encode']) && $field['encode'] == true) && isset($data[$field['field']])) {
 				$data[$field['field']] = base64_encode(str_replace(array('+', '/'), array('-', '_'), $data[$field['field']]));
 			}
 		}


### PR DESCRIPTION
...but not including that field in the search

I found this issue whilst having a search param on the "modified" field with an encode=true value in the controller which is only used on the admin_index, and having a separate search for the frontend that takes a single "query" parameter. PrgComponent correctly ignores everything that isn't set to encode=true but gives an undefined index error:

public $presetVars = array(
    // For admin area only
    array('field' => 'display_name', 'type' => 'value'),
    array('field' => 'published', 'type' => 'value'),
    array('field' => 'views', 'type' => 'value'),
    array('field' => 'downloads', 'type' => 'value'),
    array('field' => 'ref', 'type' => 'value'),
    array('field' => 'status', 'type' => 'value'),
    array('field' => 'modified', 'type' => 'value', 'encode' => true), //<-- undefined index error when searching from the front-end and only passing in type and query
    array('field' => 'root_id', 'type' => 'value'),
    array('field' => 'category_id', 'type' => 'value'),
    // for front-end search
    array('field' => 'type', 'type' => 'value'),
    array('field' => 'query', 'type' => 'value')
);
