### PR TITLE
Fix the encoding of fields which generates non url safe characters

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -86,7 +86,7 @@ class PrgComponent extends Component {
 			if ($this->encode == true || isset($field['encode']) && $field['encode'] == true) {
 				// Its important to set it also back to the controllers passed args!
 				if (isset($args[$field['field']])) {
-					$this->controller->passedArgs[$field['field']] = $args[$field['field']] = str_replace(array('-', '_'), array('+', '/'), base64_decode($args[$field['field']]));
+					$this->controller->passedArgs[$field['field']] = $args[$field['field']] = base64_decode(str_replace(array('-', '_'), array('+', '/'), $args[$field['field']]));
 				}
 			}
 
@@ -136,7 +136,7 @@ class PrgComponent extends Component {
 			}
 
 			if ($this->encode == true || isset($field['encode']) && $field['encode'] == true) {
-				$data[$field['field']] = base64_encode(str_replace(array('+', '/'), array('-', '_'), $data[$field['field']]));
+				$data[$field['field']] = str_replace(array('+', '/'), array('-', '_'), base64_encode($data[$field['field']]));
 			}
 		}
 		return $data;

--- a/Test/Case/Controller/Component/PrgComponentTest.php
+++ b/Test/Case/Controller/Component/PrgComponentTest.php
@@ -392,6 +392,25 @@ class PrgComponentTest extends CakeTestCase {
 	}
 
 /**
+ * testSerializeParamsWithEncodingWithSpecialChars
+ *
+ * @return void
+ */
+	public function testSerializeParamsWithEncodingWithNonSafeChars() {
+		$this->Controller->action = 'search';
+		$this->Controller->presetVars = array(
+			array('field' => 'title', 'type' => 'value', 'encode' => true));
+		$this->Controller->data = array();
+		$this->Controller->Post->filterArgs = array(
+			array('name' => 'title', 'type' => 'value'));
+
+		$this->Controller->Prg->encode = true;
+		$test = array('title' => 'João');
+		$result = $this->Controller->Prg->serializeParams($test);
+		$this->assertEqual($result['title'], str_replace(array('+', '/'), array('-', '_'), base64_encode('João')));
+	}
+
+/**
  * testSerializeParamsWithEncoding
  *
  * @return void
@@ -422,6 +441,9 @@ class PrgComponentTest extends CakeTestCase {
 	public function testPresetFormWithEncodedParams() {
 		$this->Controller->presetVars = array(
 			array(
+				'field' => 'name',
+				'type' => 'value'),
+			array(
 				'field' => 'title',
 				'type' => 'value'),
 			array(
@@ -434,6 +456,7 @@ class PrgComponentTest extends CakeTestCase {
 				'modelField' => 'title',
 				'model' => 'Post'));
 		$this->Controller->passedArgs = array(
+			'name' => str_replace(array('+', '/'), array('-', '_'), base64_encode('joão')),
 			'title' => base64_encode('test'),
 			'checkbox' => base64_encode('test|test2|test3'),
 			'lookup' => base64_encode('1'));
@@ -444,6 +467,7 @@ class PrgComponentTest extends CakeTestCase {
 		$this->Controller->Prg->presetForm('Post');
 		$expected = array(
 			'Post' => array(
+				'name' => 'joão',
 				'title' => 'test',
 				'checkbox' => array(
 					0 => 'test',


### PR DESCRIPTION
I noticed that the str_replace() which replaces non safe characters was being called in the inverse order, so when you encode those fields the replace should occur after the base64 encoding, and in the other way around when they're decoded.
