### PR TITLE
A minor update to searchable, which allows you to pass FALSE from your '...

### DIFF
--- a/models/behaviors/searchable.php
+++ b/models/behaviors/searchable.php
@@ -251,7 +251,7 @@ class SearchableBehavior extends ModelBehavior {
 	protected function _addCondQuery(Model $model, &$conditions, $data, $field) {
 		if ((method_exists($model, $field['method']) || $this->__checkBehaviorMethods($model, $field['method'])) && (!empty($data[$field['name']]) || (isset($data[$field['name']]) && ($data[$field['name']] === 0 || $data[$field['name']] === '0')))) {
 			$conditionsAdd = $model->{$field['method']}($data);
-			if ($conditionsAdd!==false) {
+			if ($conditionsAdd !== false) {
 				$conditions = array_merge($conditions, (array)$conditionsAdd);
 			}
 		}
@@ -293,7 +293,7 @@ class SearchableBehavior extends ModelBehavior {
 		$fieldName = $field['field'];
 		if ((method_exists($model, $field['method']) || $this->__checkBehaviorMethods($model, $field['method'])) && (!empty($data[$field['name']]) || (isset($data[$field['name']]) && ($data[$field['name']] === 0 || $data[$field['name']] === '0')))) {
 			$subquery = $model->{$field['method']}($data);
-			if ($subquery!==false) {
+			if ($subquery !== false) {
 				$conditions[] = array("$fieldName in ($subquery)");
 			}
 		}


### PR DESCRIPTION
...subquery' [_addCondSubquery()] and 'query' [_addCondQuery()] methods and bypass the addition to the search criteria -- this allows you to break out of passing a search condition based on some 'special case' values or processing... cheap and easy
