### PR TITLE
Avoid undefined index error due to empty criteria

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -147,7 +147,7 @@ class PrgComponent extends Component {
 			}
 
 			if ($field['type'] == 'lookup') {
-				if (isset($args[$field['field']])) {
+				if (!empty($args[$field['field']])) {
 					$searchModel = $field['model'];
 					$this->controller->loadModel($searchModel);
 					$this->controller->{$searchModel}->recursive = -1;


### PR DESCRIPTION
This could happen with lookup field that allow empty value.
