### PR TITLE
Fixing composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "cakedc/search",
 	"type": "cakephp-plugin",
-	"description": "The Search plugin allows you to make any kind of data searchable, enabling you to implement a robust searching rapidly."
+	"description": "The Search plugin allows you to make any kind of data searchable, enabling you to implement a robust searching rapidly.",
 	"homepage": "http://github.com/CakeDC/search",
 	"license": "MIT",
 	"authors": [


### PR DESCRIPTION
A very simple forgotten comma makes a Composer require/install impossible as it fails to parse the composer.json file from this repository.
