### PR TITLE
Replaced left-over deprecated paginate() through Paginator->paginate()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,8 @@ Associated snippet for the controller class:
 
 		public function find() {
 			$this->Prg->commonProcess();
-			$this->paginate['conditions'] = $this->Article->parseCriteria($this->Prg->parsedParams());
-			$this->set('articles', $this->paginate());
+			$this->Paginator->settings['conditions'] = $this->Article->parseCriteria($this->passedArgs);
+			$this->set('articles', $this->Paginator->paginate());
 		}
 	}
 


### PR DESCRIPTION
https://github.com/cakephp/cakephp/blob/master/lib/Cake/Controller/Controller.php#L1071

According to @burzum this should have been fixed in the develop branch:
https://github.com/CakeDC/search/pull/82#issuecomment-20945858

But as it seems there was some leftovers ;-)
