### PR TITLE
Always allow custom wildcards

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -260,31 +260,24 @@ class SearchableBehavior extends ModelBehavior {
 			if ($field['after'] === true) {
 				$field['after'] = '%';
 			}
-			//if both before and after are false, LIKE allows custom placeholders, % and _ are always treated as normal chars
+
 			$options = $this->settings[$Model->alias];
 			$from = $to = $substFrom = $substTo = array();
-			if ($options['wildcardAny'] !== '%' || ($field['before'] !== false || $field['after'] !== false)) {
+			if ($options['wildcardAny'] !== '%') {
 				$from[] = '%';
 				$to[] = '\%';
+				$from[] = $options['wildcardAny'];
+				$to[] = '%';
 			}
-			if ($options['wildcardOne'] !== '_' || ($field['before'] !== false || $field['after'] !== false)) {
+			if ($options['wildcardOne'] !== '_') {
 				$from[] = '_';
 				$to[] = '\_';
+				$from[] = $options['wildcardOne'];
+				$to[] = '_';
 			}
 			$value = $data[$field['name']];
 			if (!empty($from)) {
 				$value = str_replace($from, $to, $value);
-			}
-			if ($field['before'] === false && $field['after'] === false) {
-				if ($options['wildcardAny'] !== '%') {
-					$substFrom[] = $options['wildcardAny'];
-					$substTo[] = '%';
-				}
-				if ($options['wildcardOne'] !== '_') {
-					$substFrom[] = $options['wildcardOne'];
-					$substTo[] = '_';
-				}
-				$value = str_replace($substFrom, $substTo, $value);
 			}
 
 			if (!empty($field['connectorAnd']) || !empty($field['connectorOr'])) {

--- a/Test/Case/Model/Behavior/SearchableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/SearchableBehaviorTest.php
@@ -363,8 +363,23 @@ class SearchableTest extends CakeTestCase {
 		$expected = array('Article.title LIKE' => '%First_');
 		$this->assertEquals($expected, $result);
 
+		$data = array('faketitle' => 'F?rst');
+		$this->Article->Behaviors->Searchable->settings['Article']['like']['before'] = true;
+		$this->Article->Behaviors->Searchable->settings['Article']['like']['after'] = true;
+		$result = $this->Article->parseCriteria($data);
+		$expected = array('Article.title LIKE' => '%F_rst%');
+		$this->assertEquals($expected, $result);
+
+		$data = array('faketitle' => 'F*t');
+		$this->Article->Behaviors->Searchable->settings['Article']['like']['before'] = true;
+		$this->Article->Behaviors->Searchable->settings['Article']['like']['after'] = true;
+		$result = $this->Article->parseCriteria($data);
+		$expected = array('Article.title LIKE' => '%F%t%');
+		$this->assertEquals($expected, $result);
+
 		// now we try the default wildcards % and _
 		$data = array('faketitle' => '*First?');
+		$this->Article->Behaviors->Searchable->settings['Article']['like']['before'] = false;
 		$this->Article->Behaviors->Searchable->settings['Article']['like']['after'] = false;
 		$this->Article->Behaviors->Searchable->settings['Article']['wildcardAny'] = '%';
 		$this->Article->Behaviors->Searchable->settings['Article']['wildcardOne'] = '_';
@@ -383,12 +398,6 @@ class SearchableTest extends CakeTestCase {
 		$this->Article->Behaviors->Searchable->settings['Article']['like'] = false;
 		$result = $this->Article->parseCriteria($data);
 		$expected = array('Article.title LIKE' => '%First_');
-		$this->assertEquals($expected, $result);
-
-		$data = array('faketitle' => '%First_');
-		$this->Article->Behaviors->Searchable->settings['Article']['like'] = true;
-		$result = $this->Article->parseCriteria($data);
-		$expected = array('Article.title LIKE' => '%\%First\_%');
 		$this->assertEquals($expected, $result);
 
 		// multiple OR fields per field


### PR DESCRIPTION
Removed unnecessary restriction that custom wildcards are only possible when `'before'` and `'after'` are `false` (disabled).
This allows queries like:
`Text LIKE '%This _s _ T%t%'`, when `"This ?s ? T*t"` was entered as search query, while `'before'` and `'after'` are `true`.
One or the other can be false, too
