### PR TITLE
Fix Not included in the search criteria "type = lookup" in $filterArgs

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -79,7 +79,7 @@ class SearchableBehavior extends ModelBehavior {
 
 			if (in_array($field['type'], array('like'))) {
 				$this->_addCondLike($Model, $conditions, $data, $field);
-			} elseif (in_array($field['type'], array('value'))) {
+			} elseif (in_array($field['type'], array('value', 'lookup'))) {
 				$this->_addCondValue($Model, $conditions, $data, $field);
 			} elseif ($field['type'] === 'expression') {
 				$this->_addCondExpression($Model, $conditions, $data, $field);


### PR DESCRIPTION
The following cases, 'blog_id' is not included in the search criteria.

ex)

``` PHP
ArticlesController->$presetVars = true;

Article->$filterArgs = array(
    'blog_id' => array('type' => 'lookup', 'formField' => 'blog_input', 'modelField' => 'title', 'model' => 'Blog')
);
```
