### PR TITLE
Fix to read proper model from component configuration

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -128,8 +128,8 @@ class PrgComponent extends Component {
 		}
 
 		$model = $this->controller->modelClass;
-		if (!empty($settings['model'])) {
-			$model = $settings['model'];
+		if (!empty($this->_defaults['presetForm']['model'])) {
+			$model = $this->_defaults['presetForm']['model'];
 		}
 
 		if ($this->controller->presetVars === true) {


### PR DESCRIPTION
The $settings is not set in init() method, so model should be read from component's settings.
