### PR TITLE
improve merging of strict key based options

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -42,8 +42,8 @@ class SearchableBehavior extends ModelBehavior {
  * @return void
  */
 	public function setup(Model $Model, $config = array()) {
-		$this->_defaults = array_merge($this->_defaults, (array)Configure::read('Search.Searchable'));
-		$this->settings[$Model->alias] = array_merge($this->_defaults, $config);
+		$this->_defaults = (array)Configure::read('Search.Searchable') + $this->_defaults;
+		$this->settings[$Model->alias] = $config + $this->_defaults;
 	}
 
 /**


### PR DESCRIPTION
configs should always be merged with + operator.
its way faster and more accurate regarding nullish values.

it also unifies it with the current cake2.x and 3.x way of doing that.
