### PR TITLE
PrgComponent trying to encode non-form values

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -273,15 +273,17 @@ class PrgComponent extends Component {
 				$data[$field['field']] = $values;
 			}
 
-			if ($this->_defaults['commonProcess']['paramType'] === 'named' && ($this->encode || !empty($field['encode']))) {
-				$fieldContent = $data[$field['field']];
-				$tmp = base64_encode($fieldContent);
-				// replace chars base64 uses that would mess up the url
-				$tmp = str_replace(array('/', '='), array('-', '_'), $tmp);
-				$data[$field['field']] = $tmp;
-			}
-			if (!empty($field['empty']) && isset($data[$field['field']]) && $data[$field['field']] === '') {
-				unset($data[$field['field']]);
+			if ( isset($field['field']) && isset( $data[$field['field']] ) ) {
+				if ($this->_defaults['commonProcess']['paramType'] === 'named' && ($this->encode || !empty($field['encode']))) {
+					$fieldContent = $data[$field['field']];
+					$tmp = base64_encode($fieldContent);
+					// replace chars base64 uses that would mess up the url
+					$tmp = str_replace(array('/', '='), array('-', '_'), $tmp);
+					$data[$field['field']] = $tmp;
+				}
+				if (!empty($field['empty']) && $data[$field['field']] === '') {
+					unset($data[$field['field']]);
+				}
 			}
 		}
 		return $data;


### PR DESCRIPTION
Adjusting PrgComponent to not fail on fields that don't exist in the search form data.

   Though the controller has a $presetVars = true; ( which is incorrect configuration ) the search attempts to encode fields that aren't in the form data.
   The isset check prevents the undefined indexes from breaking the search.
