### PR TITLE
Implementing parseCriteria() in the Prg component.

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -257,6 +257,22 @@ class PrgComponent extends Component {
 	}
 
 /**
+ * Parse Criteria
+ *
+ * Parses the GET data and returns the conditions for the find('all')/paginate
+ * we are just going to test if the params are legit.
+ *
+ * @return array
+ */
+	public function parseCriteria() {
+		$model = $this->controller->modelClass;
+		if (!empty($this->_defaults['presetForm']['model'])) {
+			$model = $this->_defaults['presetForm']['model'];
+		}
+		return $this->controller->{$model}->parseCriteria($this->parsedParams());
+	}
+
+/**
  * Restores form params for checkboxes and other url encoded params
  *
  * @param array

--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -78,9 +78,10 @@ class SearchableBehavior extends ModelBehavior {
 	}
 
 /**
- * parseCriteria
- * parses the GET data and returns the conditions for the find('all')/paginate
- * we are just going to test if the params are legit
+ * Parse Criteria
+ *
+ * Parses the GET data and returns the conditions for the find('all')/paginate
+ * we are just going to test if the params are legit.
  *
  * @param Model $Model
  * @param array $data Criteria of key->value pairs from post/named parameters


### PR DESCRIPTION
Convenience method to just type 

``` php
$this->Prg->parseCriteria();
```

instead of

``` php
$this->Model->parseCriteria($this->Prg->parsedParams());
```

which is easy to forget and annoying to type.
