### PR TITLE
Use Component::beforeFilter() instead of initialize()

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -90,7 +90,7 @@ class PrgComponent extends Component {
  * @return void
  */
 	public function beforeFilter(Event $event) {
-		$this->controller = $event->subject();
+		$this->controller = $this->_registry->getController();
 
 		// fix for not throwing warnings
 		if (!isset($this->controller->presetVars)) {


### PR DESCRIPTION
Component::initialize() has been updated in CakePHP 3 to match other initialize() methods.
As per https://github.com/cakephp/cakephp/pull/4823
