### PR TITLE
Refactor: use switch case instead of else if for better code readability

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -205,27 +205,30 @@ class PrgComponent extends Component {
 				$fieldContent = str_replace(array('-', '_'), array('/', '='), $args[$field['field']]);
 				$args[$field['field']] = base64_decode($fieldContent);
 			}
-
-			if ($field['type'] === 'lookup') {
-				if (!empty($args[$field['field']])) {
-					$searchModel = $field['model'];
-					$this->controller->loadModel($searchModel);
-					$this->controller->{$searchModel}->recursive = -1;
-					$result = $this->controller->{$searchModel}->findById($args[$field['field']]);
+			
+			switch ($field['type']) {
+				case 'lookup':
+					if (!empty($args[$field['field']])) {
+						$searchModel = $field['model'];
+						$this->controller->loadModel($searchModel);
+						$this->controller->{$searchModel}->recursive = -1;
+						$result = $this->controller->{$searchModel}->findById($args[$field['field']]);
+						$parsedParams[$field['field']] = $args[$field['field']];
+						$parsedParams[$field['formField']] = $result[$searchModel][$field['modelField']];
+						$data[$model][$field['field']] = $args[$field['field']];
+						$data[$model][$field['formField']] = $result[$searchModel][$field['modelField']];
+					}
+					break;
+				
+				case 'checkbox':
+					$values = explode('|', $args[$field['field']]);
+					$parsedParams[$field['field']] = $values;
+					$data[$model][$field['field']] = $values;
+					break;
+				case 'value':
 					$parsedParams[$field['field']] = $args[$field['field']];
-					$parsedParams[$field['formField']] = $result[$searchModel][$field['modelField']];
 					$data[$model][$field['field']] = $args[$field['field']];
-					$data[$model][$field['formField']] = $result[$searchModel][$field['modelField']];
-				}
-
-			} elseif ($field['type'] === 'checkbox') {
-				$values = explode('|', $args[$field['field']]);
-				$parsedParams[$field['field']] = $values;
-				$data[$model][$field['field']] = $values;
-
-			} elseif ($field['type'] === 'value') {
-				$parsedParams[$field['field']] = $args[$field['field']];
-				$data[$model][$field['field']] = $args[$field['field']];
+					break;
 			}
 
 			if (isset($data[$model][$field['field']]) && $data[$model][$field['field']] !== '') {


### PR DESCRIPTION
Refactor: use switch case instead of else if for better code readability and performance enhancement 

Signed-off-by: Alaa Attya Mohamed <vidooman@gmail.com>