### PR TITLE
Fix empty Model->alias in validateSearch

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -124,6 +124,9 @@ class SearchableBehavior extends ModelBehavior {
 		if (!empty($data)) {
 			$Model->set($data);
 		}
+		if (empty($Model->data[$Model->alias])) {
+			return true;
+		}
 		$keys = array_keys($Model->data[$Model->alias]);
 		foreach ($keys as $key) {
 			if (empty($Model->data[$Model->alias][$key])) {


### PR DESCRIPTION
When you submit request data to Search (via Prg->commonProcess)
It should have the Model->alias parent...
But when it doesn't, it should not throw errors like these:
http://puu.sh/jAnAl/8cd53bfca7.png

Instead it should gracefully exit, no search filtering, but no errors.

To test:

Setup as normal for the Model `Content`
Then submit `$this->request->data = ['Post' => ['foo' => 'bar']]`