### PR TITLE
Drastically speed up running parseCriteria() on simple searches against models with a lot of behaviors

### DIFF
--- a/Model/Behavior/SearchableBehavior.php
+++ b/Model/Behavior/SearchableBehavior.php
@@ -431,7 +431,10 @@ class SearchableBehavior extends ModelBehavior {
 	protected function _addCondExpression(Model $Model, &$conditions, $data, $field) {
 		$fieldName = $field['field'];
 
-		if ((method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method'])) && (!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))) {
+		if (
+			(!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))
+			&& (method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method']))
+		) {
 			$fieldValues = $Model->{$field['method']}($data, $field);
 			if (!empty($conditions[$fieldName]) && is_array($conditions[$fieldName])) {
 				$conditions[$fieldName] = array_unique(array_merge(array($conditions[$fieldName]), array($fieldValues)));
@@ -452,7 +455,10 @@ class SearchableBehavior extends ModelBehavior {
  * @return array of conditions modified by this method
  */
 	protected function _addCondQuery(Model $Model, &$conditions, $data, $field) {
-		if ((method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method'])) && (!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))) {
+		if (
+			(!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))
+			&& (method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method']))
+		) {
 			$conditionsAdd = $Model->{$field['method']}($data, $field);
 			// if our conditions function returns something empty, nothing to merge in
 			if (!empty($conditionsAdd)) {
@@ -473,7 +479,10 @@ class SearchableBehavior extends ModelBehavior {
  */
 	protected function _addCondSubquery(Model $Model, &$conditions, $data, $field) {
 		$fieldName = $field['field'];
-		if ((method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method'])) && (!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))) {
+		if (
+			(!empty($field['allowEmpty']) || !empty($data[$field['name']]) || (isset($data[$field['name']]) && (string)$data[$field['name']] !== ''))
+			&& (method_exists($Model, $field['method']) || $this->_checkBehaviorMethods($Model, $field['method']))
+		) {
 			$subquery = $Model->{$field['method']}($data, $field);
 			// if our subquery function returns something empty, nothing to merge in
 			if (!empty($subquery)) {


### PR DESCRIPTION
Surprisingly, running parseCriteria() is BigO(
number_of_filter_arguments_on_behaviors * number_of_behaviors_attached *
avg_number_of_functions_in_behavior).

In other words, let's say you're doing a simple parse criteria that
turns:
[data] => Array
(
  [event_id] => 4419
  [member_id] => 88932
)
Into:
[conditions] => Array
(
  [EventsMember.member_id] => 88932
  [EventsMember.event_id] => 4419
)

But you have 20 behaviors attached with 20 functions each.  Your model
also has 20 filterArgs that exist on behaviors.

Well, this simple scan will call _checkBehaviorMethods() 20 times, which
ends up calling get_class_methods() 400 times, which ends up looping
over 8000 different function names just to "transform" the simple
conditions I listed above.

Easy fix is to change the order of the shortcircuiting behavior in
_addCondExpression, _addCondQuery, and _addCondSubquery.  When checking
to see if it should add a condition, it checks:

( function exists && i have data to add )

I changed it to:

( i have data to add && function exists )

This way, we don't needlessly run the expensive check to see if every
filter arg exists.  It is also a safe change since it's easy to verify
that it's logically equivalent since there are no side effects.

This won't fix the problem if you rely heavily on your behavior search
filters though - for that, _checkBehaviorMethods() will have to become a
bit smarter and remember what it scans instead of scanning over and over.