### PR TITLE
Change to PrgComponents query params

### DIFF
--- a/src/Controller/Component/PrgComponent.php
+++ b/src/Controller/Component/PrgComponent.php
@@ -336,7 +336,7 @@ class PrgComponent extends Component {
 			}
 
 			if ($valid) {
-				$params = $this->controller->request->query;
+				$params = [];
 				if ($keepPassed) {
 					$params = array_merge($this->controller->request->params['pass'], $params);
 					$params = $this->exclude($params, $excludedParams);


### PR DESCRIPTION
The same query param in both $params[] and in $params['?'] caused problems.The index '?' got replaced in the redirect.