### PR TITLE
Added subquery type 'subqueryExists' for queries in the form 'WHERE E…

### DIFF
--- a/Controller/Component/PrgComponent.php
+++ b/Controller/Component/PrgComponent.php
@@ -470,7 +470,7 @@ class PrgComponent extends Component {
 		if (isset($arg['presetType'])) {
 			$arg['type'] = $arg['presetType'];
 			unset($arg['presetType']);
-		} elseif (!isset($arg['type']) || in_array($arg['type'], array('expression', 'query', 'subquery', 'like', 'type', 'ilike'))) {
+		} elseif (!isset($arg['type']) || in_array($arg['type'], array('expression', 'query', 'subquery', 'subqueryExists', 'like', 'type', 'ilike'))) {
 			$arg['type'] = 'value';
 		}
 


### PR DESCRIPTION
…XISTS ()'

I stumbled upon very poor performance using subqueries in the form 'WHERE IN (SELECT...)'.
After optimizing the query I ended up with something like:
SELECT * FROM sometable a WHERE EXISTS (
  SELECT 1 FROM sometable b
  WHERE a.relevant_field = b.relevant_field
  GROUP BY b.relevant_field
  HAVING count(*) > 1)

In my case this was 60ms Vs. 30 secs.
I couldn't implement this with CakeDC/search so I added a query type 'subqueryExists'.